### PR TITLE
edge fields now end with destination type

### DIFF
--- a/bmeg/gaea/schema/sample.proto
+++ b/bmeg/gaea/schema/sample.proto
@@ -57,8 +57,8 @@ message Feature {
     // position at which this feature occurs (0-based).
     // Features spanning the join of circular genomes are represented as
     // two features one on each side of the join (position 0).
-    repeated string atPositionEdges = 2;
-    repeated string hasEffectEdges = 3;
+    repeated string atEdgesPosition = 2;
+    repeated string hasEdgesVariantEffect = 3;
 
     // Data dump/placeholder field.
     // 
@@ -91,7 +91,7 @@ message VariantCallEffect {
     string variantClassification = 3;
 
     // edges to Domain
-    repeated string inDomainEdges = 4;
+    repeated string inEdgesDomain = 4;
 
     string dbsnpRS = 5;
     string dbsnpValStatus = 6;
@@ -115,7 +115,7 @@ message VariantCall {
 
     // where on the genome this variant occurred 
     // edges to Position
-    repeated string atPositionEdges = 3;
+    repeated string atEdgesPosition = 3;
     string variantType = 4;
 
     // The reference bases for this variant. They start at the given start
@@ -133,11 +133,11 @@ message VariantCall {
     string sequencer = 10;
 
     // edges to VariantEffect
-    repeated string hasEffectEdges = 11;
+    repeated string hasEdgesVariantEffect = 11;
 
     // edges to Biosample
-    repeated string tumorSampleEdges = 12;
-    repeated string normalSampleEdges = 13;
+    repeated string tumorEdgesBiosample = 12;
+    repeated string normalEdgesBiosample = 13;
 
     // A map of additional variant call information, including a Feature Id for now...
     map<string, string> info = 14;
@@ -170,7 +170,7 @@ message Biosample {
     string sampleType = 4;
 
     // edges to GeneExpression
-    repeated string hasExpressionEdges = 5;
+    repeated string hasEdgesGeneExpression = 5;
 
     // When necessary, some way to add Biosample observations might be nice, like: map<string, sring> observations = 4;
 }
@@ -184,7 +184,7 @@ message Individual {
     string source = 2;
 
     // edges to Biosample
-    repeated string hasSampleEdges = 3;
+    repeated string hasEdgesBiosample = 3;
 
     // placeholder data dump of remaining 591 columns in summary_patient_metadata_pancan.tsv
     map<string, string> observations = 4;


### PR DESCRIPTION
Edges now have the following format:
`repeated string xxEdgesDestinationObject = 1;`
For example,
`repeated string hasEdgesVariantEffect = 3;`
