### PR TITLE
Schema to allow polymorphic edges. Simplified PhenotypeAssociation

### DIFF
--- a/bmeg/gaea/schema/sample.proto
+++ b/bmeg/gaea/schema/sample.proto
@@ -4,17 +4,6 @@ package bmeg.gaea.schema;
 
 // import "google/protobuf/struct.proto";
 
-// // Indicates the associated DNA strand for some data item.
-// enum Strand {
-//     STRAND_UNSPECIFIED = 0;
-
-//     // The negative (-) strand.
-//     NEG_STRAND = 1;
-
-//     // The postive (+) strand.
-//     POS_STRAND = 2;
-// }
-
 // A `Position` is one or more (consecutive***) bases in some `Reference`. A `Position` is
 // represented by a `Reference` name, and a base number on that `Reference`
 // (0-based).
@@ -89,11 +78,14 @@ message VariantCallEffect {
     string variantClassification = 3;
 
     // edges to Domain
-    repeated string inDomainEdgesDomain = 4;
-    repeated string inFeatureEdgesFeature = 5;
+    // Target: Domain
+    repeated string inDomainEdges = 4;
+    // Target: Feature
+    repeated string inFeatureEdges = 5;
 
     // edges to VariantEffect
-    repeated string effectOfEdgesVariantCall = 6;
+    // Target: VariantCall
+    repeated string effectOfEdges = 6;
 
     string dbsnpRS = 7;
     string dbsnpValStatus = 8;
@@ -132,12 +124,14 @@ message VariantCall {
     string sequencer = 9;
 
     // where on the genome this variant occurred 
-    // edges to Position
-    repeated string atPositionEdgesPosition = 10;
+    // Target: Position
+    repeated string atPositionEdges = 10;
 
     // edges to Biosample
-    repeated string tumorSampleEdgesBiosample = 11;
-    repeated string normalSampleEdgesBiosample = 12;
+    // Target: Biosample
+    repeated string tumorSampleEdges = 11;
+    // Target: Biosample
+    repeated string normalSampleEdges = 12;
 
     // A map of additional variant call information, including a Feature Id for now...
     map<string, string> info = 13;
@@ -170,7 +164,8 @@ message Biosample {
     string sampleType = 4;
 
     // edges to Biosample
-    repeated string sampleOfEdgesIndividual = 5;
+    // Target: Individual
+    repeated string sampleOfEdges = 5;
 
     // When necessary, some way to add Biosample observations might be nice, like: map<string, sring> observations = 4;
 }
@@ -193,7 +188,8 @@ message GeneExpression {
     string barcode = 3;
 
     // edges to GeneExpression
-    repeated string expressionForEdgesBiosample = 4;
+    // Target: Biosample
+    repeated string expressionForEdges = 4;
 
     map<string, double> expressions = 5;
 }
@@ -201,18 +197,25 @@ message GeneExpression {
 message PhenotypeAssociation {
     string name = 1;
 
-    repeated string hasGenotypeEdgesGenotype = 2;
+    // Target: VariantCall Biosample Individual Feature
+    repeated string hasGenotypeEdges = 2;
 
-    // The context is unique to the PhenotypeAssociation, so for now using containment rather than name reference.
-    Context theContext = 3;
+    // Target: Phenotype
+    repeated string hasPhenotypeEdges = 3;
 
-    repeated string hasPhenotypeEdgesPhenotype = 4;
+    // The context is unique to the PhenotypeAssociation
+    // Target: Drug Evidence
+    repeated string hasContextEdges = 4;
+
+    // Additional information about the context
+    map<string, string> info = 5;    
 }
 
 message Phenotype {
     string name = 1;
 
-    repeated string isTypeEdgesOntologyTerm = 2;
+    // Target: OntologyTerm
+    repeated string isTypeEdges = 2;
 
     string description = 3;
 }
@@ -223,40 +226,6 @@ message OntologyTerm {
     string term = 2;
     
     string source = 3;
-}
-
-message Genotype {
-    string name = 1;
-
-    // Note: We will have null fields.
-    // If the genotype is a VariantCall, specify it here.
-    repeated string isVariantCallEdgesVariantCall = 2;
-
-    // If the genotype is a Biosample, specify it here.
-    repeated string isBiosampleEdgesBiosample = 3;
-
-    // If the genotype is an Individual, specify it here.
-    repeated string isIndividualEdgesIndividual = 4;
-
-    // If the genotype is a Feature, specify it here.
-    repeated string isFeatureEdgesFeature = 5;
-}
-
-// For now, Context nodes are contained within PhenotypeAssociation (as opposed to referencing)
-message Context {
-    string name = 1;
-
-    // If applicable, specify the relevant Machine Learning Model here.
-    repeated string involvesModelEdgesModel = 2;
-
-    // If applicable, specify relevant Drug(s) here.
-    repeated string involvesDrugEdgesDrug = 3;
-
-    // Edges to other evidence for the PhenotypeAssociation
-    repeated string hasEvidenceEdgesEvidence = 4;
-
-    // Additional information about this context for the PhenotypeAssociation
-    map<string, string> info = 5;
 }
 
 message Evidence {
@@ -290,5 +259,6 @@ message LinearSignature {
     double intercept = 5;
     map<string, double> coefficients = 6;
    
-    repeated string signatureForEdgesDrug = 7;
+    // Target: Drug
+    repeated string signatureForEdges = 7;
 }

--- a/bmeg/gaea/schema/sample.proto
+++ b/bmeg/gaea/schema/sample.proto
@@ -77,13 +77,11 @@ message VariantCallEffect {
     // The feature can mean either the gene or the protein this variant is associated with.
     string variantClassification = 3;
 
-    // edges to Domain
     // Target: Domain
     repeated string inDomainEdges = 4;
     // Target: Feature
     repeated string inFeatureEdges = 5;
 
-    // edges to VariantEffect
     // Target: VariantCall
     repeated string effectOfEdges = 6;
 
@@ -127,7 +125,6 @@ message VariantCall {
     // Target: Position
     repeated string atPositionEdges = 10;
 
-    // edges to Biosample
     // Target: Biosample
     repeated string tumorSampleEdges = 11;
     // Target: Biosample
@@ -163,7 +160,6 @@ message Biosample {
     // either tumor or normal for now
     string sampleType = 4;
 
-    // edges to Biosample
     // Target: Individual
     repeated string sampleOfEdges = 5;
 
@@ -187,7 +183,6 @@ message GeneExpression {
     string source = 2;
     string barcode = 3;
 
-    // edges to GeneExpression
     // Target: Biosample
     repeated string expressionForEdges = 4;
 
@@ -203,7 +198,7 @@ message PhenotypeAssociation {
     // Target: Phenotype
     repeated string hasPhenotypeEdges = 3;
 
-    // The context is unique to the PhenotypeAssociation
+    // The context is unique to the PhenotypeAssociation. Could involve Drug or Evidence.
     // Target: Drug Evidence
     repeated string hasContextEdges = 4;
 


### PR DESCRIPTION
These changes are motivated by a few things:
- The `Genotype` message was basically a polymorphic edge. So we decided to get rid of it and have the schema support polymorphic edges.
- This means that edge field names no longer encode the name of their destination. We are instead using the line before the edge field to define the possible destinations in a comment.  
  e.g. `// Target: Biosample Individual`...
- [`FileDescriptorSet`s](https://github.com/google/protobuf/blob/master/src/google/protobuf/descriptor.proto#L726) support the encoding of comments into the descriptor, which will facilitate edge construction in UML diagrams.

There is going to be some work upfront to re-convert and import the data into the new format, but hopefully this will be neater overall.
